### PR TITLE
Register loki credentials to get them saved

### DIFF
--- a/log-elk-logger.js
+++ b/log-elk-logger.js
@@ -169,7 +169,9 @@ module.exports = function (RED) {
     {
       credentials: {
           username: {type:"text"},
-          password: {type:"password"}
+          password: {type:"password"},
+          loki_username: {type:"text"},
+          loki_password: {type:"password"}
       }
     });
 


### PR DESCRIPTION
Loki credentials did not work because of the missing registration.