### PR TITLE
feat: interpret env variable from headers

### DIFF
--- a/log-elk-logger.js
+++ b/log-elk-logger.js
@@ -3,6 +3,10 @@ module.exports = function (RED) {
     var debuglength = RED.settings.debugMaxLength || 1000;
     const safeJSONStringify = require("json-stringify-safe");
 
+    function replaceEnvVar(str) {
+      return str.replace(/\$\{(\w+)\}/g, (match, p1) => process.env[p1] || match);
+    }
+
     function LogElkLoggerNode(config) {
       var winston = require('winston');
       var winstonElasticSearch  = require('winston-elasticsearch');
@@ -61,7 +65,7 @@ module.exports = function (RED) {
           auth = this.credentials.loki_username + ':' + this.credentials.loki_password;
         }
         if (config.loki_headers) {
-          lokiHeaders = JSON.parse(config.loki_headers);
+          lokiHeaders = JSON.parse(replaceEnvVar(config.loki_headers));
         }
         if (url) {
           const lokiTransport = new LokiTransport({


### PR DESCRIPTION
This allow to define the X-Org-Id target via an environment variable, which can be useful if you have multiple nodered instances on different environments.

Example : 

```json
{"X-Scope-OrgID": "${MY_VAR}"}
```

If an env var `MY_VAR` exists with value `prod`, you'll get the following header : 

```json
{"X-Scope-OrgID": "prod"}
```

To avoid undesired replacement (if your X-Scope-OrgID contains `$`), variable's name needs to be defined as `${VAR}`

